### PR TITLE
TES-277: Fixes in the SIG image definition creation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the Packer template for creating GraphDB Azure VM images will be documented in this file.
 
+## 1.2.0
+
+### Changes
+
+- The `gallery_subscription_id` is now a required variable instead of defaulting to `subscription_id`.
+
+### Fixes
+
+- Fixed [create_image_definition.sh](create_image_definition.sh) to use `gallery_subscription_id`
+
 ## 1.1.0
 
 - Installed Azure CLI

--- a/README.md
+++ b/README.md
@@ -33,19 +33,20 @@ Follow these steps to build an AMI for GraphDB using Packer:
    The Packer configuration allows you to customize various parameters, such as the GraphDB version, Azure build and
    replication regions, subscription, client and tenant IDs. To do so, create a variables file `variables.pkrvars.hcl`,
    example file:
-      ```bash
-      subscription_id                    = "<your_azure_subscription_id>"
-      tenant_id                          = "<your_azure_tenant_id>"
-      client_id                          = "<your_azure_service_principal_id>"
-      client_secret                      = "<your_azure_service_principal_secret>"
-      build_location                     = "East US"
-      graphdb_version                    = "10.4.0"
-      gallery_image_definition           = "10.4.0-x86_64"
-      gallery_resource_group             = "Packer-RG"
-      gallery_name                       = "GraphDB"
-      gallery_image_replication_regions  = ["North Europe", "UK South"]
-      build_allowed_inbound_ip_addresses = "<your_public_IP_address>"
-      ```
+    ```bash
+    subscription_id                    = "<your_azure_subscription_id>"
+    tenant_id                          = "<your_azure_tenant_id>"
+    client_id                          = "<your_azure_service_principal_id>"
+    client_secret                      = "<your_azure_service_principal_secret>"
+    build_location                     = "East US"
+    graphdb_version                    = "10.4.0"
+    gallery_subscription_id            = "<your_azure_image_gallery_subscription_id>"
+    gallery_image_definition           = "10.4.0-x86_64"
+    gallery_resource_group             = "Packer-RG"
+    gallery_name                       = "GraphDB"
+    gallery_image_replication_regions  = ["North Europe", "UK South"]
+    build_allowed_inbound_ip_addresses = "<your_public_IP_address>"
+    ```
 
 4. **Build the AMI**:
 
@@ -85,7 +86,7 @@ The following points can be customized in a packer variables file `variables.pkr
 
 **Subscription Configuration**
 
-* `subscription_id` (string): Your Azure subscription ID.
+* `subscription_id` (string): Your Azure subscription ID. VM images will be built in this subscription.
 * `tenant_id` (string): Your Azure Active Directory tenant ID.
 * `client_id` (string): The client ID (Service Principal ID) used for authentication.
 * `client_secret` (string): The client secret (Service Principal Secret) used for authentication.
@@ -116,8 +117,7 @@ The following points can be customized in a packer variables file `variables.pkr
 
 **Gallery Configuration**
 
-* `gallery_subscription_id` (string): ID of the subscription where the Shared Image Gallery is located. Will use subscription_id as default if
-  unspecified
+* `gallery_subscription_id` (string): ID of the subscription where the Shared Image Gallery is located. Can be the same as `subscription_id`.
 * `gallery_resource_group` (string): The resource group where the image gallery is located.
 * `gallery_name` (string): The name of the image gallery.
 * `gallery_image_definition` (string): The name of the x86_64 image to use.

--- a/azure.pkr.hcl
+++ b/azure.pkr.hcl
@@ -1,8 +1,7 @@
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
   # See https://github.com/hashicorp/packer-plugin-azure/issues/65
-  version_timestamp       = formatdate("YYYY.MM.DD", timestamp())
-  gallery_subscription_id = var.gallery_subscription_id != null ? var.gallery_subscription_id : var.subscription_id
+  version_timestamp = formatdate("YYYY.MM.DD", timestamp())
 }
 
 source azure-arm ubuntu-x86-64 {
@@ -21,7 +20,7 @@ source azure-arm ubuntu-x86-64 {
   image_sku       = var.base_image_sku
 
   shared_image_gallery_destination {
-    subscription        = local.gallery_subscription_id
+    subscription        = var.gallery_subscription_id
     resource_group      = var.gallery_resource_group
     gallery_name        = var.gallery_name
     image_name          = var.gallery_image_definition

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -130,9 +130,8 @@ variable base_image_sku {
 ########################################
 
 variable gallery_subscription_id {
-  description = "ID of the subscription where the Shared Image Gallery is located. Will use subscription_id as default if unspecified."
+  description = "ID of the subscription where the Shared Image Gallery is located. Can be the same as subscription_id."
   type        = string
-  default     = null
 }
 
 variable gallery_resource_group {


### PR DESCRIPTION
## Changes

- The `gallery_subscription_id` is now a required variable
- Fixed `create_image_definition.sh` to use `gallery_subscription_id`